### PR TITLE
Optimize a bit, add README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+sum_of_squares

--- a/README.md
+++ b/README.md
@@ -1,0 +1,40 @@
+# Sum of Squares
+
+## Build
+
+With or without optimization:
+
+```bash
+# with
+gcc -O1 -pthread -o sum_of_squares sum_of_squares.c
+
+# without
+gcc -pthread -o sum_of_squares sum_of_squares.c
+```
+
+## Execute
+
+```bash
+$ ./sum_of_squares
+Time for 1 workers (wall time, total workers time): 2.582437 / 2.581940
+Time for 2 workers (wall time, total workers time): 1.310680 / 2.613840
+Time for 3 workers (wall time, total workers time): 1.069902 / 2.937649
+Time for 4 workers (wall time, total workers time): 0.743361 / 2.875449
+Time for 5 workers (wall time, total workers time): 0.758792 / 3.194261
+Time for 6 workers (wall time, total workers time): 0.664267 / 3.597698
+Time for 7 workers (wall time, total workers time): 0.618582 / 3.958804
+Time for 8 workers (wall time, total workers time): 0.559551 / 4.396329
+Time for 9 workers (wall time, total workers time): 0.624731 / 4.859120
+Time for 10 workers (wall time, total workers time): 0.621696 / 5.207822
+Time for 11 workers (wall time, total workers time): 0.606893 / 5.260752
+Time for 12 workers (wall time, total workers time): 0.573669 / 5.861300
+Time for 13 workers (wall time, total workers time): 0.579399 / 6.468218
+Time for 14 workers (wall time, total workers time): 0.595109 / 6.523404
+Time for 15 workers (wall time, total workers time): 0.578506 / 7.310590
+Time for 16 workers (wall time, total workers time): 0.563451 / 8.010766
+Total work done (sum of squares from 100 to 5000000000): 470444716059854368
+Total time taken: 13.0510 seconds
+Cumulative time for all workers: 75.6579 seconds
+
+```
+


### PR DESCRIPTION
In main(), an array of structures is declared, each worker thread is passed one element of that array, containing the specification of the work to be done and a "result" variable to store the result.

Initially each thread was using "result" from the passed struct during its sum of squares computations, reading and updating it every iteration of the computation loop. This seemed to create a bottleneck, such that it was taking about as long for two threads to do the same work vs a single thread (things got a bit better with more worker threads).

The bottleneck above was relieved by having each thread allocate a local "result" var to use when doing computations. With this change, it takes about half the time with two worker threads vs one.